### PR TITLE
Fix format bug when string is like "rst==1'b1"

### DIFF
--- a/src/main/java/net/ericsonj/verilog/decorations/SpacesBlockingAssignment.java
+++ b/src/main/java/net/ericsonj/verilog/decorations/SpacesBlockingAssignment.java
@@ -15,7 +15,7 @@ public class SpacesBlockingAssignment extends AbstractLineDecoration {
             return line;
         }
         if (line.matches(".*[^<]=.*")) {
-            String aux = line.replaceAll("[ ]*[^=!<>&|~\\^+\\-*/]=[ ]*", StringHelper.getSpaces(format.getSpacesBlockingAssignment()) + "=" + StringHelper.getSpaces(format.getSpacesBlockingAssignment()));
+            String aux = line.replaceAll("[ ]*(?<![=!<>&|~^+\\-*/])=", StringHelper.getSpaces(format.getSpacesBlockingAssignment()) + "=").replaceAll("=(?![=])[ ]*", "=" + StringHelper.getSpaces(format.getSpacesBlockingAssignment()));
             return aux;
         }
         return line;


### PR DESCRIPTION
In the latest version, there are two problems.
1. When meeting `==` string, `[ ]*[^=!<>&|~\\^+\\-*/]=[ ]*` will match the first '=' operator because there is no operator before it and there is zero ' ' after it. So '==' will be formatted into ' = ='.
2. At the same time, `[^=!<>&|~\\^+\\-*/]` will match a character which is not operator. In this case, 't' will be match, so the final result after formatting is `rs = =1'b1`, which is wrong.

I format the blank before '=' and after '=' separately to solve problem 1 and use Non-Capturing Groups `(?<!)`/`(?!)` instead of `[^]` to solve problem 2.