### PR TITLE
Fix the bug when indenting multiple modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-target/
-nbactions.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+nbactions.xml
+.idea/

--- a/src/main/java/net/ericsonj/verilog/statements/Module.java
+++ b/src/main/java/net/ericsonj/verilog/statements/Module.java
@@ -43,6 +43,7 @@ public class Module extends LineIndentable {
             case WAIT_ENDMODULE:
                 if (matchesEndmodule(line)) {
                     format.states.poll();
+                    format.resCountIndent();
                     return indent(format, moduleState.getBaseIndent(), line);
                 }
                 break;


### PR DESCRIPTION
Fixed the error where redundant indents were added when formatting a .v file with multiple modules, 
reported by issue https://github.com/ericsonj/verilog-format/issues/31