### PR TITLE
build: support Java 8+ runtimes on modern JDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Console application for apply format to verilog file.
 
 ![sample](images/verilog-format.gif)
 
+## Runtime Requirement
+
+Requires Java 8 or newer (`>= 1.8`).
+
 ## How to use
 
 Application options:

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,7 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>
@@ -52,7 +51,7 @@
             <plugin>
                 <groupId>com.akathist.maven.plugins.launch4j</groupId>
                 <artifactId>launch4j-maven-plugin</artifactId>
-                <version>1.5.2</version>
+                <version>2.6.0</version>
                 <executions>
                     <execution>
                         <id>l4j-cli</id>
@@ -70,8 +69,7 @@
                                 <mainClass>net.ericsonj.verilog.VerilogFormat</mainClass>
                             </classPath>
                             <jre>
-                                <minVersion>1.7.0</minVersion>
-                                <maxVersion>1.8.0</maxVersion>
+                                <minVersion>1.8.0</minVersion>
                                 <initialHeapSize>512</initialHeapSize>
                                 <maxHeapSize>1024</maxHeapSize>
                             </jre>


### PR DESCRIPTION
# Summary

Fix build and runtime compatibility issues with modern JDKs while standardizing the project on Java 8+.

# Background

The current release artifacts fail to run unless using exactly Java 8, due to a hard runtime cap (maxVersion=1.8.0) and outdated build configuration. This makes the project unusable on newer JDKs (9+), which is the default in most environments today.

# Changes

- Maven build
  - Switched to --release 8 to properly target Java 8 APIs
  - Eliminates the legacy source/target + bootstrap classpath mismatch
- launch4j plugin
  - Upgraded from 1.5.2 → 2.6.0 for compatibility with modern JDKs
  - Removed maxVersion=1.8.0 restriction
  - Set minimum runtime to 1.8.0
- Documentation
  - Updated README to explicitly state: Java 8 or newer is required

# Result

- Build works correctly on modern JDKs
- Generated artifacts run on Java 8+, instead of being artificially limited to Java 8 only
- Windows packaging via Launch4j works with current toolchains

# Notes

This change does not increase the minimum required Java version — it remains Java 8 — but removes unnecessary constraints that prevented usage on newer runtimes.